### PR TITLE
Add decisions to the reichlab repo exception list

### DIFF
--- a/src/reporule/data/repos_exception.yml
+++ b/src/reporule/data/repos_exception.yml
@@ -14,6 +14,7 @@ organizations:
     - flusight-eval
     - nba-predictions
     - reichlab.github.io
+    - decisions
 - name: hubverse-org
   # to use reporule ruleset with hubverse-io, add any repo that should
   # be excluded from the ruleset application to the list below


### PR DESCRIPTION
This repo had a "bespoke" ruleset that disallows pushing directly to main but doesn't require updated PRs to be re-reviewed. This works well for the decision workflow process, so let's leave it.